### PR TITLE
Redesign blog with warm earth-tone palette and single-column layout

### DIFF
--- a/blog/styles.css
+++ b/blog/styles.css
@@ -1,4 +1,13 @@
-/* Common Blog Styles */
+/* Common Blog Styles — Warm Earth Tone Palette
+   Primary:    #6B4E3D (warm brown)
+   Dark:       #3D3229 (text/headings)
+   Medium:     #5C4033 (subheadings/accents)
+   Taupe:      #8B7355 (warm accent)
+   Sage:       #7A8B6F (muted green accent)
+   Background: #FAF7F2 (warm cream)
+   Sand:       #F0EBE3 (callout backgrounds)
+*/
+
 * {
     margin: 0;
     padding: 0;
@@ -8,18 +17,18 @@
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     line-height: 1.8;
-    color: #333;
-    background-color: #f5f5f5;
+    color: #3D3229;
+    background-color: #FAF7F2;
 }
 
 .container {
-    max-width: 800px;
+    max-width: 900px;
     margin: 0 auto;
     padding: 20px;
 }
 
 header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-color: #4A3728;
     color: white;
     padding: 60px 20px;
     margin-bottom: 40px;
@@ -30,26 +39,32 @@ header .container {
 }
 
 header h1 {
+    font-family: Georgia, 'Times New Roman', serif;
     font-size: 2.5em;
     margin-bottom: 15px;
     line-height: 1.2;
+    font-weight: 400;
+    letter-spacing: 0.01em;
 }
 
 header p {
-    font-size: 1.2em;
-    opacity: 0.95;
+    font-size: 1.15em;
+    opacity: 0.85;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.95em;
 }
 
 .breadcrumb {
-    background-color: white;
+    background-color: #FFFDF9;
     padding: 15px 25px;
     border-radius: 8px;
     margin-bottom: 30px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    box-shadow: 0 1px 3px rgba(61,50,41,0.08);
 }
 
 .breadcrumb a {
-    color: #667eea;
+    color: #6B4E3D;
     text-decoration: none;
     font-weight: 500;
 }
@@ -59,76 +74,79 @@ header p {
 }
 
 article {
-    background-color: white;
+    background-color: #FFFDF9;
     padding: 50px;
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(61,50,41,0.08);
     margin-bottom: 40px;
 }
 
 article h2 {
-    color: #2c3e50;
-    margin-top: 25px;
-    margin-bottom: 12px;
-    font-size: 1.8em;
-    border-bottom: 3px solid #667eea;
+    font-family: Georgia, 'Times New Roman', serif;
+    color: #3D3229;
+    margin-top: 35px;
+    margin-bottom: 16px;
+    font-size: 1.7em;
+    font-weight: 400;
+    border-bottom: 2px solid #D4C4B0;
     padding-bottom: 10px;
 }
 
 article h3 {
-    color: #34495e;
-    margin-top: 20px;
+    color: #5C4033;
+    margin-top: 24px;
     margin-bottom: 10px;
-    font-size: 1.4em;
+    font-size: 1.3em;
 }
 
 article p {
-    margin-bottom: 12px;
-    font-size: 1.1em;
-    text-align: justify;
+    margin-bottom: 14px;
+    font-size: 1.08em;
+    line-height: 1.85;
 }
 
 article ul, article ol {
-    margin: 12px 0 12px 30px;
+    margin: 14px 0 14px 30px;
 }
 
 article li {
-    margin-bottom: 4px;
+    margin-bottom: 6px;
     font-size: 1.05em;
+    line-height: 1.7;
 }
 
 .key-points {
-    background-color: #f0f7ff;
-    border-left: 4px solid #667eea;
-    padding: 20px;
-    margin: 20px 0;
+    background-color: #F0EBE3;
+    border-left: 4px solid #8B7355;
+    padding: 20px 25px;
+    margin: 24px 0;
     border-radius: 5px;
 }
 
 .key-points h3 {
     margin-top: 0;
-    color: #667eea;
+    color: #6B4E3D;
 }
 
 .tip-box,
 .important-box {
-    background-color: #e8f5e9;
-    border-left: 4px solid #4caf50;
-    padding: 20px;
-    margin: 20px 0;
+    background-color: #EBF0E7;
+    border-left: 4px solid #7A8B6F;
+    padding: 20px 25px;
+    margin: 24px 0;
     border-radius: 5px;
 }
 
 .warning-box {
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
-    padding: 20px;
-    margin: 20px 0;
+    background-color: #F5EDE0;
+    border-left: 4px solid #C4A265;
+    padding: 20px 25px;
+    margin: 24px 0;
     border-radius: 5px;
 }
 
 .warning-box h3 {
-    color: #ffc107;
+    color: #96793A;
     margin-top: 0;
 }
 
@@ -141,11 +159,11 @@ article li {
 
 .nav-button {
     display: inline-block;
-    padding: 15px 30px;
-    background-color: #667eea;
+    padding: 14px 28px;
+    background-color: #6B4E3D;
     color: white;
     text-decoration: none;
-    border-radius: 5px;
+    border-radius: 6px;
     transition: background-color 0.3s;
     font-weight: 500;
     text-align: center;
@@ -153,30 +171,31 @@ article li {
 }
 
 .nav-button:hover {
-    background-color: #5568d3;
+    background-color: #5C4033;
 }
 
 .nav-button.back {
-    background-color: #95a5a6;
+    background-color: #9C8B7A;
 }
 
 .nav-button.back:hover {
-    background-color: #7f8c8d;
+    background-color: #87776A;
 }
 
 footer {
     text-align: center;
     padding: 30px 20px;
-    color: #666;
+    color: #8B7E72;
+    font-size: 0.95em;
 }
 
 /* Index page specific styles */
 .intro {
-    background-color: white;
-    padding: 30px;
+    background-color: #FFFDF9;
+    padding: 35px;
     border-radius: 8px;
     margin-bottom: 40px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(61,50,41,0.08);
 }
 
 .intro p {
@@ -192,120 +211,121 @@ footer {
 
 .upcoming-button {
     display: inline-block;
-    background-color: #9b59b6;
+    background-color: #7A8B6F;
     color: white;
-    padding: 15px 35px;
+    padding: 14px 32px;
     text-decoration: none;
-    border-radius: 5px;
+    border-radius: 6px;
     transition: background-color 0.3s, transform 0.2s;
     font-weight: 500;
-    font-size: 1.1em;
+    font-size: 1.05em;
 }
 
 .upcoming-button:hover {
-    background-color: #8e44ad;
+    background-color: #697D63;
     transform: translateY(-2px);
 }
 
 .blog-posts {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 20px;
-}
-
-@media (max-width: 768px) {
-    .blog-posts {
-        grid-template-columns: 1fr;
-    }
+    grid-template-columns: 1fr;
+    gap: 16px;
 }
 
 .post-card {
-    background-color: white;
-    padding: 30px;
+    background-color: #FFFDF9;
+    padding: 28px 32px;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    transition: transform 0.3s, box-shadow 0.3s;
+    box-shadow: 0 1px 4px rgba(61,50,41,0.08);
+    transition: box-shadow 0.3s;
+    border-left: 3px solid transparent;
 }
 
 .post-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+    box-shadow: 0 2px 8px rgba(61,50,41,0.13);
+    border-left-color: #D4C4B0;
 }
 
 .post-card h2 {
-    color: #2c3e50;
-    margin-bottom: 15px;
-    font-size: 1.8em;
+    font-family: Georgia, 'Times New Roman', serif;
+    color: #3D3229;
+    margin-bottom: 8px;
+    font-size: 1.45em;
+    font-weight: 400;
 }
 
 .post-card p {
-    color: #666;
-    margin-bottom: 20px;
-    font-size: 1.05em;
+    color: #6B5E52;
+    margin-bottom: 12px;
+    font-size: 1.02em;
+    line-height: 1.7;
 }
 
 .post-card a {
     display: inline-block;
-    background-color: #3498db;
-    color: white;
-    padding: 12px 25px;
+    color: #6B4E3D;
+    padding: 0;
     text-decoration: none;
-    border-radius: 5px;
-    transition: background-color 0.3s;
-    font-weight: 500;
+    font-weight: 600;
+    font-size: 0.95em;
+    background: none;
+    transition: color 0.2s;
 }
 
 .post-card a:hover {
-    background-color: #2980b9;
+    color: #8B7355;
+    background: none;
 }
 
 /* Summary lists in post cards */
 .summary-list {
     list-style-type: disc;
-    margin: 15px 0 20px 25px;
+    margin: 10px 0 14px 25px;
     padding: 0;
     font-size: 0.95em;
 }
 
 /* Quick Reference / Highlighted Post Card */
 .post-card-highlight {
-    border-left: 4px solid #e74c3c;
-    background: linear-gradient(135deg, #fff5f5 0%, #ffffff 100%);
+    border-left: 3px solid #8B7355;
+    background-color: #F9F5EE;
 }
 
 .summary-list li {
-    color: #555;
+    color: #5C5047;
     margin-bottom: 6px;
     line-height: 1.5;
 }
 
 /* Content Analysis Section */
 .content-analysis {
-    background-color: white;
+    background-color: #FFFDF9;
     padding: 40px;
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(61,50,41,0.08);
     margin-top: 40px;
 }
 
 .content-analysis h2 {
-    color: #2c3e50;
+    font-family: Georgia, 'Times New Roman', serif;
+    color: #3D3229;
     margin-bottom: 30px;
     font-size: 1.8em;
-    border-bottom: 3px solid #667eea;
+    font-weight: 400;
+    border-bottom: 2px solid #D4C4B0;
     padding-bottom: 10px;
 }
 
 .content-analysis h3 {
-    color: #34495e;
+    color: #5C4033;
     margin-top: 25px;
     margin-bottom: 15px;
     font-size: 1.3em;
 }
 
 .overlap-section {
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
+    background-color: #F5EDE0;
+    border-left: 4px solid #C4A265;
     padding: 25px;
     margin: 20px 0;
     border-radius: 5px;
@@ -313,7 +333,7 @@ footer {
 
 .overlap-section h3 {
     margin-top: 0;
-    color: #856404;
+    color: #7A6330;
 }
 
 .overlap-section ul {
@@ -326,8 +346,8 @@ footer {
 }
 
 .split-section {
-    background-color: #e8f5e9;
-    border-left: 4px solid #4caf50;
+    background-color: #EBF0E7;
+    border-left: 4px solid #7A8B6F;
     padding: 25px;
     margin: 20px 0;
     border-radius: 5px;
@@ -335,7 +355,7 @@ footer {
 
 .split-section h3 {
     margin-top: 0;
-    color: #2e7d32;
+    color: #5A6E50;
 }
 
 .split-section ul {
@@ -355,7 +375,7 @@ footer {
 .split-section ul ul li {
     margin-bottom: 4px;
     font-style: italic;
-    color: #555;
+    color: #5C5047;
 }
 
 /* Responsive styles */
@@ -363,37 +383,37 @@ footer {
     header h1 {
         font-size: 2em;
     }
-    
+
     article {
         padding: 30px 25px;
     }
-    
+
     .navigation {
         flex-direction: column;
     }
-    
+
     .post-card {
-        padding: 20px;
+        padding: 22px 20px;
     }
-    
+
     .post-card h2 {
-        font-size: 1.5em;
+        font-size: 1.3em;
     }
 }
 
 /* Upcoming Topics Section */
 .upcoming-topics {
-    background: linear-gradient(135deg, #f0f7ff 0%, #e8f0ff 100%);
-    border-left: 4px solid #667eea;
+    background-color: #F0EBE3;
+    border-left: 4px solid #8B7355;
     padding: 25px 30px;
     border-radius: 8px;
     margin-bottom: 25px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    box-shadow: 0 1px 3px rgba(61,50,41,0.06);
 }
 
 .upcoming-topics h3 {
     margin: 0 0 15px 0;
-    color: #667eea;
+    color: #6B4E3D;
     font-size: 1.2em;
 }
 
@@ -403,57 +423,57 @@ footer {
 }
 
 .upcoming-topics li {
-    color: #444;
+    color: #4A3F36;
     line-height: 1.6;
     margin-bottom: 8px;
 }
 
 /* Favourite Tools Section */
 .favourite-tools {
-    background-color: white;
+    background-color: #FFFDF9;
     padding: 30px;
     border-radius: 8px;
     margin-bottom: 40px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(61,50,41,0.08);
 }
 
 .favourite-tools h3 {
     margin: 0 0 20px 0;
-    color: #2c3e50;
+    color: #3D3229;
     font-size: 1.3em;
 }
 
 .tool-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 15px;
+    gap: 12px;
 }
 
 .tool-card {
     display: flex;
     flex-direction: column;
-    padding: 20px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    padding: 18px 20px;
+    background-color: #4A3728;
     border-radius: 8px;
     text-decoration: none;
     color: white;
-    transition: transform 0.3s, box-shadow 0.3s;
+    transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .tool-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.4);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(74,55,40,0.3);
 }
 
 .tool-name {
     font-weight: 600;
-    font-size: 1.05em;
-    margin-bottom: 5px;
+    font-size: 1.02em;
+    margin-bottom: 4px;
 }
 
 .tool-desc {
     font-size: 0.85em;
-    opacity: 0.9;
+    opacity: 0.85;
 }
 
 @media (max-width: 768px) {
@@ -484,19 +504,19 @@ article img {
     height: 180px;
     object-fit: cover;
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    box-shadow: 0 2px 8px rgba(61,50,41,0.12);
     transition: transform 0.3s, box-shadow 0.3s;
 }
 
 .image-gallery img:hover {
     transform: scale(1.02);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+    box-shadow: 0 4px 12px rgba(61,50,41,0.2);
 }
 
 .image-gallery figcaption {
     text-align: center;
     font-size: 0.85em;
-    color: #666;
+    color: #6B5E52;
     margin-top: 8px;
     font-style: italic;
 }
@@ -516,12 +536,12 @@ article img {
     margin-left: auto;
     margin-right: auto;
     display: block;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 12px rgba(61,50,41,0.12);
 }
 
 /* Memorial Image Section */
 .memorial-section {
-    background-color: #f8f9fa;
+    background-color: #F5F0E8;
     padding: 30px;
     border-radius: 8px;
     margin: 40px 0;
@@ -529,7 +549,7 @@ article img {
 }
 
 .memorial-section h3 {
-    color: #2c3e50;
+    color: #3D3229;
     margin-bottom: 20px;
 }
 
@@ -537,7 +557,7 @@ article img {
     max-width: 400px;
     height: auto;
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 12px rgba(61,50,41,0.12);
     margin-bottom: 15px;
 }
 
@@ -553,12 +573,12 @@ article img {
     max-height: 300px;
     object-fit: cover;
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 12px rgba(61,50,41,0.12);
 }
 
 .memorial-caption {
     font-style: italic;
-    color: #666;
+    color: #6B5E52;
     margin-top: 10px;
 }
 
@@ -567,20 +587,20 @@ article img {
         grid-template-columns: 1fr;
         max-width: 300px;
     }
-    
+
     .image-gallery img {
         height: 160px;
     }
-    
+
     .hero-image {
         max-width: 100%;
         max-height: 250px;
     }
-    
+
     .quality-metric-figure {
         max-width: 300px;
     }
-    
+
     .quality-metric-figure img {
         max-height: 250px;
     }
@@ -592,10 +612,10 @@ article img {
 }
 
 .upcoming-topics h2 {
-    color: #667eea;
+    color: #6B4E3D;
     margin-top: 30px;
     margin-bottom: 15px;
-    border-bottom: 2px solid #667eea;
+    border-bottom: 2px solid #D4C4B0;
     padding-bottom: 8px;
 }
 
@@ -606,15 +626,14 @@ article img {
 }
 
 .topic-list li {
-    background-color: #f8f9fa;
+    background-color: #F5F0E8;
     padding: 12px 20px;
     margin-bottom: 10px;
     border-radius: 5px;
-    border-left: 3px solid #667eea;
+    border-left: 3px solid #8B7355;
     font-size: 1.05em;
 }
 
 .topic-list li:empty {
     display: none;
 }
-


### PR DESCRIPTION
Replace the purple/blue tech-startup aesthetic with warm browns, taupes, and sage greens that complement the blog's palliative care subject matter and Reiker's photos. Switch index page from cramped 2-column card grid to single-column layout for better readability. Add serif headings, remove text-align justify, and unify callout box colors.

https://claude.ai/code/session_01TjQSRDvoGNTqLfAXeKWrkt